### PR TITLE
Add convenient columns to admin application list

### DIFF
--- a/organizers/tables.py
+++ b/organizers/tables.py
@@ -60,7 +60,8 @@ class AdminApplicationsListTable(tables.Table):
         model = Application
         attrs = {'class': 'table table-hover'}
         template = 'django_tables2/bootstrap-responsive.html'
-        fields = ['selected', 'counter', 'user.name', 'vote_avg', 'review_count', 'reimb_amount', 'university', 'origin']
+        fields = ['selected', 'counter', 'user.name', 'vote_avg',
+                  'review_count', 'reimb_amount', 'university', 'origin']
         empty_text = 'No applications available'
         order_by = '-vote_avg'
 

--- a/organizers/tables.py
+++ b/organizers/tables.py
@@ -50,6 +50,8 @@ class ApplicationsListTable(tables.Table):
 
 class AdminApplicationsListTable(tables.Table):
     selected = tables.CheckBoxColumn(accessor="pk", verbose_name='Select')
+    counter = tables.TemplateColumn('{{ row_counter|add:1 }}', verbose_name='Position')
+    review_count = tables.Column(accessor='vote_set.count', verbose_name='# of reviews')
     detail = tables.TemplateColumn(
         "<a href='{% url 'app_detail' record.uuid %}'>Detail</a> ",
         verbose_name='Actions', orderable=False)
@@ -58,7 +60,7 @@ class AdminApplicationsListTable(tables.Table):
         model = Application
         attrs = {'class': 'table table-hover'}
         template = 'django_tables2/bootstrap-responsive.html'
-        fields = ['selected', 'user.name', 'vote_avg', 'reimb_amount', 'university', 'origin']
+        fields = ['selected', 'counter', 'user.name', 'vote_avg', 'review_count', 'reimb_amount', 'university', 'origin']
         empty_text = 'No applications available'
         order_by = '-vote_avg'
 


### PR DESCRIPTION
## What this PR does / Why we need it

This PR adds two columns to the table in the admin application list (i.e., in the Invite tab):

- A row counter, the same way we have it in the organizer ranking list. Requested by Marina.
- The number of reviews/votes it has gotten. I think this will help directors see how legitimate the score is. 

## Some questions
- [x] I have read the contributing guidelines
- [x] I abide by this repository Code of Conduct
- [x] I understand that my PR won't be merged until Travis gives a "green light"

<!--You can leave this and check them once the PR has been created.-->